### PR TITLE
Fix for CVE-2019-11324

### DIFF
--- a/docs/de/requirements.txt
+++ b/docs/de/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/es/requirements.txt
+++ b/docs/es/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/fr/requirements.txt
+++ b/docs/fr/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/ja/requirements.txt
+++ b/docs/ja/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/ko/requirements.txt
+++ b/docs/ko/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/nl/requirements.txt
+++ b/docs/nl/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/pt/requirements.txt
+++ b/docs/pt/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/ru/requirements.txt
+++ b/docs/ru/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/uk/requirements.txt
+++ b/docs/uk/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9

--- a/docs/zh/requirements.txt
+++ b/docs/zh/requirements.txt
@@ -31,6 +31,6 @@ sphinx-rtd-theme==0.4.2
 sphinxcontrib-websupport==1.0.1
 tornado==4.5.3
 typing==3.6.2
-urllib3==1.22
+urllib3==1.24.2
 watchdog==0.8.3
 yarg==0.1.9


### PR DESCRIPTION
### Description of the Change
Updating urllib3 version to urllib3==1.24.2

### Benefits
Despite the issue is theoretical, it is better to stay updated
https://www.cvedetails.com/cve/CVE-2019-11324/

### Possible Drawbacks
There is a very small chance of SSL problems. In case there are any, rollback to the previous urllib3 version.